### PR TITLE
fix/portion size parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@types/node": "^22.7.5",
         "eslint": "^9.12.0",
         "hot-hook": "^0.3.1",
+        "nock": "^13.5.6",
         "pino-pretty": "^11.2.2",
         "prettier": "^3.3.3",
         "ts-node-maintained": "^10.9.4",
@@ -5992,6 +5993,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/jsonschema": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
@@ -6561,6 +6569,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
       }
     },
     "node_modules/node-cron": {
@@ -7563,6 +7586,16 @@
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
       "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "license": "MIT"
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/node": "^22.7.5",
     "eslint": "^9.12.0",
     "hot-hook": "^0.3.1",
+    "nock": "^13.5.6",
     "pino-pretty": "^11.2.2",
     "prettier": "^3.3.3",
     "ts-node-maintained": "^10.9.4",

--- a/scripts/menu_scrapper.ts
+++ b/scripts/menu_scrapper.ts
@@ -7,7 +7,7 @@ import WebsiteHash from '#models/website_hash'
 import logger from '@adonisjs/core/services/logger'
 import HashesMeal from '#models/hashes_meal'
 
-const url = 'https://sks.pwr.edu.pl/menu/'
+export const url = 'https://sks.pwr.edu.pl/menu/'
 
 export async function runScrapper() {
   const trx = await db.transaction()
@@ -65,7 +65,7 @@ export async function scrapeMenu() {
           const nameMatch = itemText.match(/[\D\s]+/)
           const itemName = nameMatch ? nameMatch[0].trim() : itemText
 
-          const sizeMatch = itemText.match(/\d+(?:g|ml)(?:\/\d+(?:g|ml))?/)
+          const sizeMatch = itemText.match(/\d+(?:g|ml)?(?:\/\d+(?:g|ml)?)?/)
           const itemSize = sizeMatch ? sizeMatch[0].trim() : null
 
           return {

--- a/scripts/menu_scrapper.ts
+++ b/scripts/menu_scrapper.ts
@@ -65,7 +65,7 @@ export async function scrapeMenu() {
           const nameMatch = itemText.match(/[\D\s]+/)
           const itemName = nameMatch ? nameMatch[0].trim() : itemText
 
-          const sizeMatch = itemText.match(/\d+(?:g|ml)?(?:\/\d+(?:g|ml)?)?/)
+          const sizeMatch = itemText.match(/\d+(?:g|ml)?(?:\/\d+(?:g|ml)?)?\s+(?=\d+(?=\.\d+)?)/)
           const itemSize = sizeMatch ? sizeMatch[0].trim() : null
 
           return {

--- a/tests/fixtures/external_menu_response.html
+++ b/tests/fixtures/external_menu_response.html
@@ -67,7 +67,7 @@
             <div class="pos_group">
               <div class="pos">
                 <ul>
-                  <li> Ryż biały na sypko 200g <span class="price"> 4.00</span>
+                  <li> Ryż biały na sypko <span class="price"> 4.00</span>
                   </li>
                   <li> Ziemniaki z koperkiem 250g <span class="price"> 4.50</span>
                   </li>

--- a/tests/fixtures/external_menu_response.html
+++ b/tests/fixtures/external_menu_response.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <body>
+    <div id="main">
+      <div id="menu">
+        <div id="menu_table">
+          <div class="category">
+            <div class="cat_name">
+              <h2>Surówki</h2>
+            </div>
+            <div class="pos_group">
+              <div class="pos">
+                <ul>
+                  <li> Surówka z selera z rodzynkami 100g <span class="price"> 4.00</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="category">
+            <div class="cat_name">
+              <h2>Zupy</h2>
+            </div>
+            <div class="pos_group">
+              <div class="pos">
+                <ul>
+                  <li> Kapuśniak z białej kapusty 300ml <span class="price"> 6.50</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="category">
+            <div class="cat_name">
+              <h2>Dania jarskie</h2>
+            </div>
+            <div class="pos_group">
+              <div class="pos">
+                <ul>
+                  <li> Papryka fasz.k.maz.mozzar.i p.susz 300g <span class="price"> 15.00</span>
+                  </li>
+                  <li> Pampuchy drożdż. z sosem trus 250/50 <span class="price"> 15.00</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="category">
+            <div class="cat_name">
+              <h2>Dania mięsne</h2>
+            </div>
+            <div class="pos_group">
+              <div class="pos">
+                <ul>
+                  <li> Pieczeń z karczku w natur.sosie 110g/50g <span class="price"> 15.00</span>
+                  </li>
+                  <li> Stek drobiowy w s. pieczarkowym 120/50g <span class="price"> 15.00</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="category">
+            <div class="cat_name">
+              <h2>Dodatki</h2>
+            </div>
+            <div class="pos_group">
+              <div class="pos">
+                <ul>
+                  <li> Ryż biały na sypko 200g <span class="price"> 4.00</span>
+                  </li>
+                  <li> Ziemniaki z koperkiem 250g <span class="price"> 4.50</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="category">
+            <div class="cat_name">
+              <h2>Kompoty i napoje</h2>
+            </div>
+            <div class="pos_group">
+              <div class="pos">
+                <ul>
+                  <li> Napój z soku jabłkowego 200ml <span class="price"> 2.50</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/parsed_menu_expected_response.ts
+++ b/tests/fixtures/parsed_menu_expected_response.ts
@@ -1,0 +1,56 @@
+export const expectedResponse = [
+  {
+    name: 'Surówka z selera z rodzynkami',
+    size: '100g',
+    price: 4,
+    category: 'SALAD',
+  },
+  {
+    name: 'Kapuśniak z białej kapusty',
+    size: '300ml',
+    price: 6.5,
+    category: 'SOUP',
+  },
+  {
+    name: 'Papryka fasz.k.maz.mozzar.i p.susz',
+    size: '300g',
+    price: 15,
+    category: 'VEGETARIAN_DISH',
+  },
+  {
+    name: 'Pampuchy drożdż. z sosem trus',
+    size: '250/50',
+    price: 15,
+    category: 'VEGETARIAN_DISH',
+  },
+  {
+    name: 'Pieczeń z karczku w natur.sosie',
+    size: '110g/50g',
+    price: 15,
+    category: 'MEAT_DISH',
+  },
+  {
+    name: 'Stek drobiowy w s. pieczarkowym',
+    size: '120/50g',
+    price: 15,
+    category: 'MEAT_DISH',
+  },
+  {
+    name: 'Ryż biały na sypko',
+    size: '200g',
+    price: 4,
+    category: 'SIDE_DISH',
+  },
+  {
+    name: 'Ziemniaki z koperkiem',
+    size: '250g',
+    price: 4.5,
+    category: 'SIDE_DISH',
+  },
+  {
+    name: 'Napój z soku jabłkowego',
+    size: '200ml',
+    price: 2.5,
+    category: 'DRINK',
+  },
+]

--- a/tests/fixtures/parsed_menu_expected_response.ts
+++ b/tests/fixtures/parsed_menu_expected_response.ts
@@ -37,7 +37,7 @@ export const expectedResponse = [
   },
   {
     name: 'Ryż biały na sypko',
-    size: '200g',
+    size: null,
     price: 4,
     category: 'SIDE_DISH',
   },

--- a/tests/unit/menuScrapper/scrape_menu.spec.ts
+++ b/tests/unit/menuScrapper/scrape_menu.spec.ts
@@ -1,0 +1,16 @@
+import { test } from '@japa/runner'
+import nock from 'nock'
+import { expectedResponse } from '#tests/fixtures/parsed_menu_expected_response'
+import { scrapeMenu } from '../../../scripts/menu_scrapper.js'
+import { url } from '../../../scripts/menu_scrapper.js'
+
+test.group('Menu scrapper scrape menu', () => {
+  test('should parse the external menu response', async ({ assert }) => {
+    nock(url).get('/').replyWithFile(200, './tests/fixtures/external_menu_response.html', {
+      'Content-Type': 'text/html; charset=UTF-8',
+    })
+
+    const response = await scrapeMenu()
+    assert.deepEqual(response, expectedResponse)
+  })
+})


### PR DESCRIPTION
Here we are fixing parsing the response from the sks API (portion size). 
We are adjusting the portion size regex by adding the `?`quantifiers to allow `g` or `ml` suffixes to be skipped.
That way the problematic `Pampuchy drożdż. z sosem trus 250/50` will have the portion size property filled.